### PR TITLE
Feature/feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,4 +279,29 @@ least one sample attribute is different in openBIS and SEEK
 4. assets attached to the experiment or samples will be created, if they are missing from this assay
 5. no existing sample or assets are deleted from SEEK, even if they are missing from openBIS
 
+**Example command:**
+
+`java -jar target/openbis-scripts-1.0.0-jar-with-dependencies.jar openbis-to-seek /MYSPACE/PROJECTY/00_P_INFO_691 mystudy -d -config config.txt --openbis-pw --seek-pw`
+
+**Example output:**
+
+    Transfer openBIS -> SEEK started.
+    Provided openBIS object: /MYSPACE/PROJECTY/00_P_INFO_691
+    Provided SEEK study title: mystudy
+    No SEEK project title provided, will search config file.
+    Transfer datasets to SEEK? true
+    Update existing nodes if found? true
+    Connecting to openBIS...
+    Searching for specified object in openBIS...
+    Search successful.
+    Connecting to SEEK...
+    Collecting information from openBIS...
+    Translating openBIS property codes to SEEK names...
+    Creating SEEK structure...
+    Trying to find existing corresponding assay in SEEK...
+    Found assay with id 64
+    Updating nodes...
+    Mismatch found in Gender attribute of /MYSPACE/PROJECTY/00_P_INFO_691. Sample will be updated.
+    http://localhost:3000/assays/64 was successfully updated.
+
 ## Caveats and Future Options

--- a/README.md
+++ b/README.md
@@ -263,6 +263,16 @@ The data itself can be transferred and stored in SEEK using the '-d' flag.
 To completely exclude some dataset information from being transferred, a file ('--blacklist') 
 containing dataset codes (from openBIS) can be specified. //TODO do this for samples/sample types
 
+In order to store links to the newly created SEEK objects in the source openBIS instance, the 
+following sample type is needed:
+
+    Sample Type Code: EXTERNAL_LINK
+    Property: LINK_TYPE (VARCHAR)
+    Property: URL (VARCHAR)
+
+EXTERNAL_LINK samples are added to transferred experiments and samples and point to their respective
+counterparts in SEEK. If the sample type is not available, this will be logged.
+
 ### Updating nodes in SEEK based on updates in openBIS
 
 Updating nodes in SEEK uses the same general command, parameters and options. Unless otherwise 

--- a/src/main/java/life/qbic/io/PetabParser.java
+++ b/src/main/java/life/qbic/io/PetabParser.java
@@ -73,12 +73,22 @@ public class PetabParser {
     Path path = Paths.get(Objects.requireNonNull(findYaml(new File(outputPath))).getPath());
     Charset charset = StandardCharsets.UTF_8;
 
-    final String keyWord = "openBISId";
+    final String idKeyWord = "openBISId";
 
-    String idInLine = keyWord+":(.*)?(\\r\\n|[\\r\\n])";
+    final String endOfLine = ":(.*)?(\\r\\n|[\\r\\n])";
+    final String idInLine = idKeyWord+endOfLine;
 
     String content = Files.readString(path, charset);
-    content = content.replaceAll(idInLine, keyWord+": "+datasetCode+"\n");
+    // existing property found, fill/replace with relevant dataset code
+    if(content.contains(idKeyWord)) {
+      content = content.replaceAll(idInLine, idKeyWord+": "+datasetCode+"\n");
+      // no existing property found, create it above the dateOfExperiment property
+    } else {
+      String dateKeyword = "dateOfExperiment";
+      String dateLine = dateKeyword+endOfLine;
+      String newLines = idKeyWord+": "+datasetCode+"\n  "+dateKeyword+":\n";
+      content = content.replaceAll(dateLine, newLines);
+    }
     Files.write(path, content.getBytes(charset));
   }
 

--- a/src/main/java/life/qbic/io/commandline/UploadDatasetCommand.java
+++ b/src/main/java/life/qbic/io/commandline/UploadDatasetCommand.java
@@ -25,13 +25,15 @@ import picocli.CommandLine.Parameters;
  * otherwise the type "UNKNOWN" will be used.
  */
 @Command(name = "upload-data",
-    description = "uploads a dataset and attaches it to an experiment and (optionally) other datasets")
+    description = "uploads a dataset and attaches it to an experiment or sample and (optionally) "
+        + "other datasets")
 public class UploadDatasetCommand implements Runnable {
 
   @Parameters(arity = "1", paramLabel = "file/folder", description = "The path to the file or folder to upload")
   private String dataPath;
-  @Parameters(arity = "1", paramLabel = "object ID", description = "The full identifier of the experiment or sample the data should be attached to. "
-      + "The identifier must be of the format: /space/project/experiment for experiments or /space/sample for samples")
+  @Parameters(arity = "1", paramLabel = "object ID", description = "The full identifier of the "
+      + "experiment or sample the data should be attached to. The identifier must be of the format: "
+      + "/space/project/experiment for experiments or /space/sample for samples")
   private String objectID;
   @Option(arity = "1..*", paramLabel = "<parent_datasets>", description = "Optional list of dataset codes to act"
       + " as parents for the upload. E.g. when this dataset has been generated using these datasets as input.", names = {"-pa", "--parents"})

--- a/src/main/java/life/qbic/model/download/OpenbisConnector.java
+++ b/src/main/java/life/qbic/model/download/OpenbisConnector.java
@@ -545,7 +545,7 @@ public class OpenbisConnector {
     SampleTypeFetchOptions typeOptions = new SampleTypeFetchOptions();
     typeOptions.withPropertyAssignments().withPropertyType();
     typeOptions.withPropertyAssignments().withEntityType();
-    if(openBIS.searchSampleTypes(criteria, typeOptions).getObjects().size() == 0) {
+    if(openBIS.searchSampleTypes(criteria, typeOptions).getObjects().isEmpty()) {
       System.out.printf(
           "This is where links would be put into openBIS, but EXTERNAL_LINK sample was "
               + "not yet added to openBIS instance.%n");

--- a/src/main/java/life/qbic/model/download/SEEKConnector.java
+++ b/src/main/java/life/qbic/model/download/SEEKConnector.java
@@ -137,8 +137,6 @@ public class SEEKConnector {
         .send(buildAuthorizedPOSTRequest(endpoint, assay.toJson()),
             BodyHandlers.ofString());
 
-    System.err.println(assay.toJson());
-
     if(response.statusCode()!=200) {
       throw new RuntimeException("Failed : HTTP error code : " + response.statusCode());
     }

--- a/src/main/java/life/qbic/model/download/SEEKConnector.java
+++ b/src/main/java/life/qbic/model/download/SEEKConnector.java
@@ -50,6 +50,7 @@ public class SEEKConnector {
   private byte[] credentials;
   private OpenbisSeekTranslator translator;
   private final String DEFAULT_PROJECT_ID;
+  private String currentStudy;
   private final List<String> ASSET_TYPES = new ArrayList<>(Arrays.asList("data_files", "models",
       "sops", "documents", "publications"));
 
@@ -75,7 +76,8 @@ public class SEEKConnector {
 
   public void setDefaultStudy(String studyTitle)
       throws URISyntaxException, IOException, InterruptedException {
-    translator.setDefaultStudy(searchNodeWithTitle("studies", studyTitle));
+    this.currentStudy = searchNodeWithTitle("studies", studyTitle);
+    translator.setDefaultStudy(currentStudy);
   }
 
   /**
@@ -500,18 +502,24 @@ public class SEEKConnector {
    * @throws IOException
    * @throws InterruptedException
    */
-  public List<String> searchAssaysContainingKeyword(String searchTerm)
+  public List<String> searchAssaysInStudyContainingKeyword(String searchTerm)
       throws URISyntaxException, IOException, InterruptedException {
 
     JsonNode result = genericSearch("assays", "*"+searchTerm+"*");
 
     JsonNode hits = result.path("data");
-    List<String> assayIDs = new ArrayList<>();
+    List<String> assayIDsInStudy = new ArrayList<>();
     for (Iterator<JsonNode> it = hits.elements(); it.hasNext(); ) {
       JsonNode hit = it.next();
-      assayIDs.add(hit.get("id").asText());
+      String assayID = hit.get("id").asText();
+      JsonNode assayData = fetchAssayData(assayID).get("data");
+      JsonNode relationships = assayData.get("relationships");
+      String studyID = relationships.get("study").get("data").get("id").asText();
+      if(studyID.equals(currentStudy)) {
+        assayIDsInStudy.add(assayID);
+      }
     }
-    return assayIDs;
+    return assayIDsInStudy;
   }
 
   /**
@@ -556,8 +564,10 @@ public class SEEKConnector {
   /**
    * Updates information of an existing assay, its samples and attached assets. Missing samples and
    * assets are created, but nothing missing from the new structure is deleted from SEEK.
+   *
    * @param nodeWithChildren the translated Seek structure as it should be once the update is done
-   * @param assayID the assay id of the existing assay, that should be compared to the new structure
+   * @param assayID          the assay id of the existing assay, that should be compared to the new
+   *                         structure
    * @return information necessary to make post registration updates in openBIS and upload missing
    * data to newly created assets. In the case of the update use case, only newly created objects
    * will be contained in the return object.
@@ -585,9 +595,9 @@ public class SEEKConnector {
 
           boolean oldEmpty = oldValue == null || oldValue.toString().isEmpty();
           boolean newEmpty = newValue == null || newValue.toString().isEmpty();
-          if ((!oldEmpty && !newEmpty) && !newValue.equals(oldValue)) {
-            System.out.printf("Mismatch found in attributes of %s. Sample will be updated.%n",
-                openBisID);
+          if ((!oldEmpty && !newEmpty) && !newValue.toString().equals(oldValue.toString())) {
+            System.out.printf("Mismatch found in %s attribute of %s. Sample will be updated.%n",
+                key, openBisID);
             newSample.setAssayIDs(List.of(assayID));
             updateSample(newSample, existingSample.getSeekID());
           }
@@ -840,6 +850,7 @@ public class SEEKConnector {
 
     Pair<ISAAssay, String> assayIDPair = nodeWithChildren.getAssayWithOpenBISReference().get();
 
+    System.out.println("Creating assay...");
     String assayID = addAssay(assayIDPair.getKey());
     String assayEndpoint = apiURL+"/assays/"+assayID;
     Pair<String, String> experimentIDWithEndpoint =
@@ -850,6 +861,9 @@ public class SEEKConnector {
 
     Map<String, String> sampleIDsWithEndpoints = new HashMap<>();
     Map<ISASample, String> samplesWithReferences = nodeWithChildren.getSamplesWithOpenBISReference();
+    if(!samplesWithReferences.isEmpty()) {
+      System.out.println("Creating samples...");
+    }
     for(ISASample sample : samplesWithReferences.keySet()) {
       sample.setAssayIDs(Collections.singletonList(assayID));
       String sampleEndpoint = createSample(sample);
@@ -857,6 +871,10 @@ public class SEEKConnector {
     }
 
     Map<GenericSeekAsset, DataSetFile> isaToFileMap = nodeWithChildren.getISAFileToDatasetFiles();
+
+    if(!isaToFileMap.isEmpty()) {
+      System.out.println("Creating assets...");
+    }
 
     List<AssetToUpload> assetsToUpload = createAssetsForAssays(isaToFileMap,
         Collections.singletonList(assayID));

--- a/src/main/java/life/qbic/model/isa/NodeType.java
+++ b/src/main/java/life/qbic/model/isa/NodeType.java
@@ -1,0 +1,5 @@
+package life.qbic.model.isa;
+
+public enum NodeType {
+  ASSAY, SAMPLE, ASSET
+}


### PR DESCRIPTION
* allow to upload PEtab to sample objects
* fix issue with PEtab download where openbis dataset id would not be added if keyword was not yet in the yaml file
* final version of sample and asset creation in SEEK, some more documentation
* add code to create links to SEEK in openBIS, which will work once the sample type has been created in an instance