### PR TITLE
Add RO-crate use case

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ The script will try to find the provided **openbis ID** in experiments, samples 
 fetch any missing information to create a SEEK node containing at least one assay (when an
 experiment without samples and datasets is specified).
 
-The seek-study needs to be provides to attach the assay. TODO: This information is also used to 
+The seek-study needs to be provided to attach the assay. TODO: This information is also used to 
 decide if the node(s) should be updated (if they exist for the provided study) or created anew.
 
 Similarly, the title of the project in SEEK where nodes should be added, can either be provided via 
@@ -291,7 +291,7 @@ least one sample attribute is different in openBIS and SEEK
 
 **Example command:**
 
-`java -jar target/openbis-scripts-1.0.0-jar-with-dependencies.jar openbis-to-seek /MYSPACE/PROJECTY/00_P_INFO_691 mystudy -d -config config.txt --openbis-pw --seek-pw`
+`java -jar scripts.jar openbis-to-seek /MYSPACE/PROJECTY/00_P_INFO_691 mystudy -d -config config.txt --openbis-pw --seek-pw`
 
 **Example output:**
 
@@ -313,5 +313,73 @@ least one sample attribute is different in openBIS and SEEK
     Updating nodes...
     Mismatch found in Gender attribute of /MYSPACE/PROJECTY/00_P_INFO_691. Sample will be updated.
     http://localhost:3000/assays/64 was successfully updated.
+
+#### RO-Crates
+
+While the creation of RO-Crates is not fully implemented, the command creates a folder and metadata
+structure based on OpenBIS experiment, sample and dataset information. The command works similarly
+to the OpenBIS to Seek command, with the difference that no SEEK instance and fewer mapping
+parameters need to be provided (there will be no references to existing study or project objects in
+SEEK).
+
+The script will try to find the provided **openbis ID** in experiments, samples or datasets and
+fetch any missing information to create a folder structure containing at least one assay (when an
+experiment without samples and datasets is specified).
+
+Info in the created asset .jsons always links back to the openBIS path of the respective dataset.
+The data itself can be downloaded into the structure using the '-d' flag.
+
+To completely exclude some dataset information from being transferred, a file ('--blacklist')
+containing dataset codes (from openBIS) can be specified. //TODO do this for samples/sample types
+
+**Example command:**
+
+`java -jar scripts.jar ro-crate /TEMP_PLAYGROUND/TEMP_PLAYGROUND/TEST_PATIENTS1 my-ro-crate -config config.txt --openbis-pw -d`
+
+**Example output:**
+
+    reading config
+    Transfer openBIS -> RO-crate started.
+    Provided openBIS object: /TEMP_PLAYGROUND/TEMP_PLAYGROUND/TEST_PATIENTS1
+    Pack datasets into crate? true
+    Connecting to openBIS...
+    Searching for specified object in openBIS...
+    Search successful.
+    Collecting information from openBIS...
+    Translating openBIS structure to ISA structure...
+    Writing assay json for /TEMP_PLAYGROUND/TEMP_PLAYGROUND/TEST_PATIENTS1.
+    Writing sample json for /TEMP_PLAYGROUND/TEMP_PLAYGROUND/00_P_INFO_670490.
+    Writing sample json for /TEMP_PLAYGROUND/TEMP_PLAYGROUND/00_P_INFO_670491.
+    Writing asset json for file in dataset 20241014205813459-689089.
+    Downloading dataset file to asset folder.
+    Writing asset json for file in dataset 20241014210001025-689090.
+    Downloading dataset file to asset folder.
+    Writing asset json for file in dataset 20241014205813459-689089.
+    Downloading dataset file to asset folder.
+    Writing asset json for file in dataset 20241021191109163-689109.
+    Downloading dataset file to asset folder.
+
+**Creates structure:**
+
+    my-ro-crate
+    └── TEMP_PLAYGROUND_TEMP_PLAYGROUND_TEST_PATIENTS1
+        ├── 20241021125328024-689105
+        │        ├── README.md
+        │        └── README.md.json
+        ├── TEMP_PLAYGROUND_TEMP_PLAYGROUND_00_P_INFO_670490
+        │        └── TEMP_PLAYGROUND_TEMP_PLAYGROUND_00_P_INFO_670490.json
+        ├── TEMP_PLAYGROUND_TEMP_PLAYGROUND_00_P_INFO_670491
+        │        ├── 20241014210317842-689092
+        │        │       ├── scripts-new.jar
+        │        │       └── scripts-new.jar.json
+        │        ├── 20241021173011602-689108
+        │        │       └── smol_petab
+        │        │           ├── metaInformation.yaml
+        │        │           └── metaInformation.yaml.json
+        │        ├── 20241021191109163-689109
+        │        │       ├── testfile_100
+        │        │       └── testfile_100.json
+        │        └── TEMP_PLAYGROUND_TEMP_PLAYGROUND_00_P_INFO_670491.json
+        └── TEMP_PLAYGROUND_TEMP_PLAYGROUND_TEST_PATIENTS1.json
 
 ## Caveats and Future Options

--- a/README.md
+++ b/README.md
@@ -323,8 +323,12 @@ parameters need to be provided (there will be no references to existing study or
 SEEK).
 
 The script will try to find the provided **openbis ID** in experiments, samples or datasets and
-fetch any missing information to create a folder structure containing at least one assay (when an
-experiment without samples and datasets is specified).
+fetch any missing information to create a folder structure in the provided **ro-path** containing at
+least one assay's information (when an experiment without samples and datasets is specified).
+
+Assets (files and their ISA metadata) are stored in a folder named like the openBIS dataset code
+they are part of, which is either the subfolder of the experiment (assay), or the subfolder of a
+sample, depending on where the dataset was attached in openBIS.
 
 Info in the created asset .jsons always links back to the openBIS path of the respective dataset.
 The data itself can be downloaded into the structure using the '-d' flag.
@@ -358,6 +362,7 @@ containing dataset codes (from openBIS) can be specified. //TODO do this for sam
     Downloading dataset file to asset folder.
     Writing asset json for file in dataset 20241021191109163-689109.
     Downloading dataset file to asset folder.
+    ...
 
 **Creates structure:**
 

--- a/src/main/java/life/qbic/io/commandline/CommandLineOptions.java
+++ b/src/main/java/life/qbic/io/commandline/CommandLineOptions.java
@@ -10,7 +10,8 @@ import picocli.CommandLine.Option;
 @Command(name = "openbis-scripts",
     subcommands = {SampleHierarchyCommand.class, TransferSampleTypesToSeekCommand.class,
         DownloadPetabCommand.class, UploadPetabResultCommand.class, UploadDatasetCommand.class,
-        SpaceStatisticsCommand.class, TransferDataToSeekCommand.class, FindDatasetsCommand.class},
+        SpaceStatisticsCommand.class, TransferDataToSeekCommand.class, FindDatasetsCommand.class,
+        CreateROCrate.class},
     description = "A client software for querying openBIS.",
     mixinStandardHelpOptions = true, versionProvider = ManifestVersionProvider.class)
 public class CommandLineOptions {

--- a/src/main/java/life/qbic/io/commandline/CreateROCrate.java
+++ b/src/main/java/life/qbic/io/commandline/CreateROCrate.java
@@ -14,7 +14,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;

--- a/src/main/java/life/qbic/io/commandline/CreateROCrate.java
+++ b/src/main/java/life/qbic/io/commandline/CreateROCrate.java
@@ -1,0 +1,238 @@
+package life.qbic.io.commandline;
+
+import ch.ethz.sis.openbis.generic.OpenBIS;
+import ch.ethz.sis.openbis.generic.dssapi.v3.dto.datasetfile.DataSetFile;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import javax.xml.parsers.ParserConfigurationException;
+import life.qbic.App;
+import life.qbic.model.DatasetWithProperties;
+import life.qbic.model.OpenbisExperimentWithDescendants;
+import life.qbic.model.OpenbisSeekTranslator;
+import life.qbic.model.download.OpenbisConnector;
+import life.qbic.model.isa.GenericSeekAsset;
+import life.qbic.model.isa.ISAAssay;
+import life.qbic.model.isa.ISASample;
+import life.qbic.model.isa.NodeType;
+import life.qbic.model.isa.SeekStructure;
+import org.xml.sax.SAXException;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+
+@Command(name = "ro-crate",
+    description =
+        "Transfers metadata and (optionally) data from openBIS to an RO-Crate-like structure that is "
+            + "based on assays, samples and one of several data types in SEEK). The data itself can "
+            + "be put into the crate using the '-d' flag. To completely exclude some dataset "
+            + "information from being transferred, a file ('--blacklist') containing dataset codes "
+            + "can be specified. The crate is not zipped at the moment.")
+public class CreateROCrate implements Runnable {
+
+  @Parameters(arity = "1", paramLabel = "openbis id", description = "The identifier of the "
+      + "experiment, sample or dataset to transfer.")
+  private String objectID;
+  @Parameters(arity = "1", paramLabel = "ro-path", description = "Path to the output folder")
+  private String roPath;
+  @Option(names = "--blacklist", description = "Path to file specifying by dataset "
+      + "dataset code which openBIS datasets not to transfer to SEEK. The file must contain one code "
+      + "per line.")
+  private String blacklistFile;
+  @Option(names = {"-d", "--data"}, description =
+      "Transfers the data itself to SEEK along with the metadata. "
+          + "Otherwise only the link(s) to the openBIS object will be created in SEEK.")
+  private boolean transferData;
+  @Mixin
+  OpenbisAuthenticationOptions openbisAuth = new OpenbisAuthenticationOptions();
+  OpenbisConnector openbis;
+  OpenbisSeekTranslator translator;
+
+  @Override
+  public void run() {
+    App.readConfig();
+    System.out.printf("Transfer openBIS -> RO-crate started.%n");
+    System.out.printf("Provided openBIS object: %s%n", objectID);
+    System.out.printf("Pack datasets into crate? %s%n", transferData);
+    if(blacklistFile!=null && !blacklistFile.isBlank()) {
+      System.out.printf("File with datasets codes that won't be transferred: %s%n", blacklistFile);
+    }
+
+    System.out.println("Connecting to openBIS...");
+
+    OpenBIS authentication = App.loginToOpenBIS(openbisAuth.getOpenbisPassword(),
+        openbisAuth.getOpenbisUser(), openbisAuth.getOpenbisAS(), openbisAuth.getOpenbisDSS());
+
+    this.openbis = new OpenbisConnector(authentication);
+
+    System.out.println("Searching for specified object in openBIS...");
+
+    boolean isExperiment = experimentExists(objectID);
+    NodeType nodeType = NodeType.ASSAY;
+
+    if (!isExperiment && sampleExists(objectID)) {
+      nodeType = NodeType.SAMPLE;
+    }
+
+    if (!isExperiment && !nodeType.equals(NodeType.SAMPLE) && datasetsExist(
+        Arrays.asList(objectID))) {
+      nodeType = NodeType.ASSET;
+    }
+
+    if (nodeType.equals(NodeType.ASSAY) && !isExperiment) {
+      System.out.printf(
+          "%s could not be found in openBIS. Make sure you either specify an experiment, sample or dataset%n",
+          objectID);
+      return;
+    }
+    System.out.println("Search successful.");
+
+    try {
+      translator = new OpenbisSeekTranslator(openbisAuth.getOpenbisBaseURL());
+    } catch (IOException | ParserConfigurationException | SAXException e) {
+      throw new RuntimeException(e);
+    }
+    OpenbisExperimentWithDescendants structure;
+    System.out.println("Collecting information from openBIS...");
+    switch (nodeType) {
+      case ASSAY:
+        structure = openbis.getExperimentWithDescendants(objectID);
+        break;
+      case SAMPLE:
+        structure = openbis.getExperimentAndDataFromSample(objectID);
+        break;
+      case ASSET:
+        structure = openbis.getExperimentStructureFromDataset(objectID);
+        break;
+      default:
+        throw new RuntimeException("Handling of node type " + nodeType + " is not supported.");
+    }
+    Set<String> blacklist = parseBlackList(blacklistFile);
+    System.out.println("Translating openBIS structure to ISA structure...");
+    try {
+      SeekStructure nodeWithChildren = translator.translateForRO(structure, blacklist, transferData);
+      String experimentID = nodeWithChildren.getAssayWithOpenBISReference().getRight();
+      ISAAssay assay = nodeWithChildren.getAssayWithOpenBISReference().getLeft();
+      String assayFileName = openbisIDToFileName(experimentID);
+
+      String assayPath = Path.of(roPath, assayFileName).toString();
+      new File(assayPath).mkdirs();
+
+      System.out.printf("Writing assay json for %s.%n", experimentID);
+      writeFile(Path.of(assayPath, assayFileName)+".json", assay.toJson());
+
+      for(ISASample sample : nodeWithChildren.getSamplesWithOpenBISReference().keySet()) {
+        String sampleID = nodeWithChildren.getSamplesWithOpenBISReference().get(sample);
+        String sampleFileName = openbisIDToFileName(sampleID);
+        String samplePath = Path.of(assayPath, sampleFileName).toString();
+        new File(samplePath).mkdirs();
+
+        System.out.printf("Writing sample json for %s.%n", sampleID);
+        writeFile(Path.of(samplePath, sampleFileName)+".json", sample.toJson());
+      }
+
+      Map<String, String> datasetIDToDataFolder = new HashMap<>();
+
+      for(DatasetWithProperties dwp : structure.getDatasets()) {
+        String sourceID = dwp.getClosestSourceID();
+        String code = dwp.getCode();
+        if(sourceID.equals(experimentID)) {
+          Path folderPath = Path.of(assayPath, code);
+          File dataFolder = new File(folderPath.toString());
+          datasetIDToDataFolder.put(dwp.getCode(), dataFolder.getAbsolutePath());
+        } else {
+          Path samplePath = Path.of(assayPath, openbisIDToFileName(sourceID), code);
+          File dataFolder = new File(samplePath.toString());
+          datasetIDToDataFolder.put(dwp.getCode(), dataFolder.getAbsolutePath());
+        }
+      }
+
+      for(GenericSeekAsset asset : nodeWithChildren.getISAFileToDatasetFiles().keySet()) {
+        DataSetFile file = nodeWithChildren.getISAFileToDatasetFiles().get(asset);
+        String datasetID = file.getDataSetPermId().getPermId();
+        String dataFolderPath = datasetIDToDataFolder.get(datasetID);
+        String assetJson = asset.toJson();
+        String assetWithoutOriginFolder = asset.getFileName().replace("original","");
+        File assetFolder = Path.of(dataFolderPath, assetWithoutOriginFolder).getParent().toFile();
+        assetFolder.mkdirs();
+
+        String assetPath = Path.of(dataFolderPath, assetWithoutOriginFolder+".json").toString();
+        System.out.printf("Writing asset json for file in dataset %s.%n", datasetID);
+        writeFile(assetPath, assetJson);
+        if(transferData) {
+          System.out.printf("Downloading dataset file to asset folder.%n");
+          openbis.downloadDataset(dataFolderPath, datasetID, asset.getFileName());
+        }
+      }
+    } catch (URISyntaxException | IOException e) {
+      throw new RuntimeException(e);
+    }
+
+    System.out.println("Done");
+  }
+
+  private String openbisIDToFileName(String id) {
+    id = id.replace("/","_");
+    if(id.startsWith("_")) {
+      return id.substring(1);
+    } else {
+      return id;
+    }
+  }
+
+  private void writeFile(String path, String content) throws IOException {
+    FileWriter file = new FileWriter(path);
+    file.write(content);
+    file.close();
+  }
+
+  private Set<String> parseBlackList(String blacklistFile) {
+    if(blacklistFile == null) {
+      return new HashSet<>();
+    }
+    // trim whitespace, skip empty lines
+    try (Stream<String> lines = Files.lines(Paths.get(blacklistFile))
+        .map(String::trim)
+        .filter(s -> !s.isBlank())) {
+
+      Set<String> codes = lines.collect(Collectors.toSet());
+
+      for(String code : codes) {
+        if(!OpenbisConnector.datasetCodePattern.matcher(code).matches()) {
+          throw new RuntimeException("Invalid dataset code: " + code+". Please make sure to use valid"
+              + " dataset codes in the blacklist file.");
+        }
+      }
+      return codes;
+    } catch (IOException e) {
+      throw new RuntimeException(blacklistFile+" could not be found or read.");
+    }
+  }
+
+  private boolean sampleExists(String objectID) {
+    return openbis.sampleExists(objectID);
+  }
+
+  private boolean datasetsExist(List<String> datasetCodes) {
+    return openbis.findDataSets(datasetCodes).size() == datasetCodes.size();
+  }
+
+  private boolean experimentExists(String experimentID) {
+    return openbis.experimentExists(experimentID);
+  }
+
+}

--- a/src/main/java/life/qbic/model/DatasetWithProperties.java
+++ b/src/main/java/life/qbic/model/DatasetWithProperties.java
@@ -57,4 +57,15 @@ public class DatasetWithProperties {
   public Date getRegistrationDate() {
     return dataset.getRegistrationDate();
   }
+
+  /**
+   * Returns sample ID or experiment ID, if Dataset has no sample.
+   */
+  public String getClosestSourceID() {
+    if(dataset.getSample()!=null) {
+      return dataset.getSample().getIdentifier().getIdentifier();
+    } else {
+      return getExperiment().getIdentifier().getIdentifier();
+    }
+  }
 }

--- a/src/main/java/life/qbic/model/OpenbisSeekTranslator.java
+++ b/src/main/java/life/qbic/model/OpenbisSeekTranslator.java
@@ -32,7 +32,6 @@ import life.qbic.model.isa.ISASampleType;
 import life.qbic.model.isa.ISASampleType.SampleAttribute;
 import life.qbic.model.isa.ISASampleType.SampleAttributeType;
 import life.qbic.model.isa.SeekStructure;
-import org.apache.commons.lang3.tuple.Pair;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -58,6 +57,80 @@ public class OpenbisSeekTranslator {
       throw new RuntimeException("Script can not be run, since 'seek_openbis_sample_title' was not "
           + "provided.");
     }
+  }
+
+  /**
+   * Used for translation to RO-Crate, without SEEK connection
+   * @param openbisBaseURL
+   */
+  public OpenbisSeekTranslator(String openbisBaseURL)
+      throws IOException, ParserConfigurationException, SAXException {
+    this.openBISBaseURL = openbisBaseURL;
+    this.DEFAULT_PROJECT_ID = null;
+    parseConfigs();
+  }
+
+  //Used for translation to RO-Crate, without SEEK connection
+  public SeekStructure translateForRO(OpenbisExperimentWithDescendants experiment,
+      Set<String> blacklist, boolean transferData) throws URISyntaxException {
+
+    Experiment exp = experiment.getExperiment();
+    String expType = exp.getType().getCode();
+    String title = exp.getCode()+" ("+exp.getPermId().getPermId()+")";
+    String assayType = experimentTypeToAssayType.get(expType);
+
+    if(assayType ==null || assayType.isBlank()) {
+      throw new RuntimeException("Could not find assay type for " + expType+". A mapping needs to "
+          + "be added to the respective properties file.");
+    }
+    ISAAssay assay = new ISAAssay(title, "-1", experimentTypeToAssayClass.get(expType),
+        new URI(assayType));
+
+    SeekStructure result = new SeekStructure(assay, exp.getIdentifier().getIdentifier());
+
+    for(Sample sample : experiment.getSamples()) {
+      SampleType sampleType = sample.getType();
+
+      //try to put all attributes into sample properties, as they should be a 1:1 mapping
+      Map<String, String> typeCodesToNames = new HashMap<>();
+      Set<String> propertiesLinkingSamples = new HashSet<>();
+      for (PropertyAssignment a : sampleType.getPropertyAssignments()) {
+        String code = a.getPropertyType().getCode();
+        String label = a.getPropertyType().getLabel();
+        DataType type = a.getPropertyType().getDataType();
+        typeCodesToNames.put(code, label);
+        if(type.equals(DataType.SAMPLE)) {
+          propertiesLinkingSamples.add(code);
+        }
+      }
+      Map<String, Object> attributes = new HashMap<>();
+      for(String code : sample.getProperties().keySet()) {
+        String value = sample.getProperty(code);
+        if(propertiesLinkingSamples.contains(code)) {
+          value = generateOpenBISLinkFromPermID("SAMPLE", value);
+        }
+        attributes.put(typeCodesToNames.get(code), value);
+      }
+
+      String sampleID = sample.getIdentifier().getIdentifier();
+      attributes.put(App.configProperties.get("seek_openbis_sample_title"), sampleID);
+      ISASample isaSample = new ISASample(sample.getIdentifier().getIdentifier(), attributes,
+          "-1", Collections.singletonList(DEFAULT_PROJECT_ID));
+      result.addSample(isaSample, sampleID);
+    }
+
+    //create ISA files for assets. If actual data is to be uploaded is determined later based on flag
+    for(DatasetWithProperties dataset : experiment.getDatasets()) {
+      String permID = dataset.getCode();
+      if(!blacklist.contains(permID)) {
+        for(DataSetFile file : experiment.getFilesForDataset(permID)) {
+          String datasetType = getDatasetTypeOfFile(file, experiment.getDatasets());
+          datasetFileToSeekAsset(file, datasetType, transferData)
+              .ifPresent(seekAsset -> result.addAsset(seekAsset, file));
+        }
+      }
+    }
+    return result;
   }
 
   /**
@@ -217,72 +290,6 @@ public class OpenbisSeekTranslator {
     }
     return result;
   }
-
-  /*
-  public SeekStructure translate(OpenbisSampleWithDatasets sampleWithDatasets,
-      Map<String, String> sampleTypesToIds, Set<String> blacklist, boolean transferData) {
-    Sample sample = sampleWithDatasets.getSample();
-    SampleType sampleType = sample.getType();
-    //try to put all attributes into sample properties, as they should be a 1:1 mapping
-    Map<String, String> typeCodesToNames = new HashMap<>();
-    Set<String> propertiesLinkingSamples = new HashSet<>();
-    for (PropertyAssignment a : sampleType.getPropertyAssignments()) {
-      String code = a.getPropertyType().getCode();
-      String label = a.getPropertyType().getLabel();
-      DataType type = a.getPropertyType().getDataType();
-      typeCodesToNames.put(code, label);
-      if (type.equals(DataType.SAMPLE)) {
-        propertiesLinkingSamples.add(code);
-      }
-    }
-    Map<String, Object> attributes = new HashMap<>();
-    for (String code : sample.getProperties().keySet()) {
-      String value = sample.getProperty(code);
-      if (propertiesLinkingSamples.contains(code)) {
-        value = generateOpenBISLinkFromPermID("SAMPLE", value);
-      }
-      attributes.put(typeCodesToNames.get(code), value);
-    }
-
-    String sampleID = sample.getIdentifier().getIdentifier();
-    attributes.put(App.configProperties.get("seek_openbis_sample_title"), sampleID);
-    String sampleTypeId = sampleTypesToIds.get(sampleType.getCode());
-    ISASample isaSample = new ISASample(sample.getIdentifier().getIdentifier(), attributes,
-        sampleTypeId, Collections.singletonList(DEFAULT_PROJECT_ID));
-    SeekStructure result = new SeekStructure(isaSample, sampleID);
-
-    //create ISA files for assets. If actual data is to be uploaded is determined later based on flag
-    List<DatasetWithProperties> datasets = sampleWithDatasets.getDatasets();
-    for (DatasetWithProperties dataset : datasets) {
-      String permID = dataset.getCode();
-      if (!blacklist.contains(permID)) {
-        for (DataSetFile file : sampleWithDatasets.getFilesForDataset(permID)) {
-          String datasetType = getDatasetTypeOfFile(file, datasets);
-          datasetFileToSeekAsset(file, datasetType, transferData)
-              .ifPresent(seekAsset -> result.addAsset(seekAsset, file));
-        }
-      }
-    }
-    return result;
-  }
-
-  public SeekStructure translate(Pair<DatasetWithProperties, List<DataSetFile>> datasetWithFiles,
-      Set<String> blacklist, boolean transferData) {
-    Map<GenericSeekAsset, DataSetFile> assetToDatasetFiles = new HashMap<>();
-    DatasetWithProperties dataset = datasetWithFiles.getLeft();
-    String permID = dataset.getCode();
-    String datasetType = dataset.getType().getCode();
-
-    if (!blacklist.contains(permID)) {
-      for (DataSetFile file : datasetWithFiles.getRight()) {
-        datasetFileToSeekAsset(file, datasetType, transferData)
-            .ifPresent(seekAsset -> assetToDatasetFiles.put(seekAsset, file));
-      }
-    }
-    return new SeekStructure(assetToDatasetFiles);
-  }
-
-   */
 
   private String getDatasetTypeOfFile(DataSetFile file, List<DatasetWithProperties> dataSets) {
     String permId = file.getDataSetPermId().getPermId();

--- a/src/main/java/life/qbic/model/download/OpenbisConnector.java
+++ b/src/main/java/life/qbic/model/download/OpenbisConnector.java
@@ -127,7 +127,6 @@ public class OpenbisConnector {
 
   private static void copyInputStreamToFile(InputStream inputStream, File file)
       throws IOException {
-    System.err.println(file.getPath());
     try (FileOutputStream outputStream = new FileOutputStream(file, false)) {
       int read;
       byte[] bytes = new byte[8192];
@@ -469,6 +468,8 @@ public class OpenbisConnector {
     DataSetFetchOptions dataSetFetchOptions = new DataSetFetchOptions();
     dataSetFetchOptions.withType();
     dataSetFetchOptions.withRegistrator();
+    dataSetFetchOptions.withExperiment();
+    dataSetFetchOptions.withSample();
     SampleFetchOptions sampleFetchOptions = new SampleFetchOptions();
     sampleFetchOptions.withProperties();
     sampleFetchOptions.withType().withPropertyAssignments().withPropertyType();
@@ -662,6 +663,8 @@ public class OpenbisConnector {
     DataSetFetchOptions dataSetFetchOptions = new DataSetFetchOptions();
     dataSetFetchOptions.withType();
     dataSetFetchOptions.withRegistrator();
+    dataSetFetchOptions.withExperiment();
+    dataSetFetchOptions.withSample();
     SampleFetchOptions fetchOptions = new SampleFetchOptions();
     fetchOptions.withProperties();
     fetchOptions.withType().withPropertyAssignments().withPropertyType();

--- a/src/main/java/life/qbic/model/download/SEEKConnector.java
+++ b/src/main/java/life/qbic/model/download/SEEKConnector.java
@@ -645,11 +645,8 @@ public class SEEKConnector {
     }
 
     String assayEndpoint = apiURL + "/assays/" + assayID;
-    if(nodeWithChildren.getAssayWithOpenBISReference().isEmpty()) {
-        throw new RuntimeException("No assay and openBIS reference found. Object has not been "
-            + "initialized using an assay object and openBIS experiment reference.");
-    }
-    String expID = nodeWithChildren.getAssayWithOpenBISReference().get().getRight();
+
+    String expID = nodeWithChildren.getAssayWithOpenBISReference().getRight();
     Pair<String, String> experimentIDWithEndpoint = new ImmutablePair<>(expID, assayEndpoint);
 
     SeekStructurePostRegistrationInformation postRegInfo =
@@ -842,13 +839,7 @@ public class SEEKConnector {
 
   public SeekStructurePostRegistrationInformation createNode(SeekStructure nodeWithChildren)
       throws URISyntaxException, IOException, InterruptedException {
-
-    if(nodeWithChildren.getAssayWithOpenBISReference().isEmpty()) {
-        throw new RuntimeException("No assay and openBIS reference found. Object has not been "
-            + "initialized using an assay object and openBIS experiment reference.");
-    }
-
-    Pair<ISAAssay, String> assayIDPair = nodeWithChildren.getAssayWithOpenBISReference().get();
+    Pair<ISAAssay, String> assayIDPair = nodeWithChildren.getAssayWithOpenBISReference();
 
     System.out.println("Creating assay...");
     String assayID = addAssay(assayIDPair.getKey());

--- a/src/main/java/life/qbic/model/isa/SeekStructure.java
+++ b/src/main/java/life/qbic/model/isa/SeekStructure.java
@@ -1,11 +1,8 @@
 package life.qbic.model.isa;
 
 import ch.ethz.sis.openbis.generic.dssapi.v3.dto.datasetfile.DataSetFile;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 
@@ -16,26 +13,14 @@ import org.apache.commons.lang3.tuple.Pair;
  */
 public class SeekStructure {
 
-  private final Optional<Pair<ISAAssay, String>> assayAndOpenBISReference;
+  private final Pair<ISAAssay, String> assayAndOpenBISReference;
   private final Map<ISASample, String> samplesWithOpenBISReference;
   private final Map<GenericSeekAsset, DataSetFile> isaToOpenBISFile;
 
   public SeekStructure(ISAAssay assay, String openBISReference) {
-    this.assayAndOpenBISReference = Optional.of(new ImmutablePair<>(assay, openBISReference));
+    this.assayAndOpenBISReference = new ImmutablePair<>(assay, openBISReference);
     this.samplesWithOpenBISReference = new HashMap<>();
     this.isaToOpenBISFile = new HashMap<>();
-  }
-
-  public SeekStructure(ISASample isaSample, String sampleID) {
-    this.samplesWithOpenBISReference = new HashMap<>();
-    this.isaToOpenBISFile = new HashMap<>();
-    this.assayAndOpenBISReference = Optional.empty();
-  }
-
-  public SeekStructure(Map<GenericSeekAsset, DataSetFile> isaToOpenBISFile) {
-    this.isaToOpenBISFile = isaToOpenBISFile;
-    this.samplesWithOpenBISReference = new HashMap<>();
-    this.assayAndOpenBISReference = Optional.empty();
   }
 
   public void addSample(ISASample sample, String openBISReference) {
@@ -46,7 +31,7 @@ public class SeekStructure {
     isaToOpenBISFile.put(asset, file);
   }
 
-  public Optional<Pair<ISAAssay, String>> getAssayWithOpenBISReference() {
+  public Pair<ISAAssay, String> getAssayWithOpenBISReference() {
     return assayAndOpenBISReference;
   }
 


### PR DESCRIPTION
* allow creation of "RO-crate like" folder structures containing metadata and possibly data, based on ISA
* allow translation into ISA objects without SEEK connection
* fetch information about a datasets attached sample and experiment and provide method to the the relevant identifier
* update README
* remove unused code